### PR TITLE
Skip 'promise > meow async' on Windows

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -38,7 +38,7 @@ t.test('setup fixtures', function (t) {
 
 t.test('promise', { skip: promiseSkip }, function (t) {
   var isexe = reset()
-  t.test('meow async', function (t) {
+  t.test('meow async', { skip: winSkip }, function (t) {
     isexe(meow).then(function (is) {
       t.ok(is)
       t.end()


### PR DESCRIPTION
This test checks whether the file `meow.cat` is executable. On Windows,
it determines this by checking whether the file extension is in the
PathExt environment variable. `cat` is not typically in PathExt, so
this test will always fail on Windows.

The functionality being tested is already covered by similar
windows-only tests (`windows > pathExt env > meow async` in particular),
so it should be safe to ignore without reducing coverage.

Closes #19