### PR TITLE
Update tap to v12.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.0",
-    "tap": "^10.3.0"
+    "tap": "^12.0.1"
   },
   "scripts": {
     "test": "tap test/*.js --100",


### PR DESCRIPTION
A dependency of `tap` (`spawn-env`, via nyc) was causing tests to fail.
Any version of `tap` >= v10.7.1 will guarantee a version of `spawn-env`
with that bug fix. The minimum has been increased to v12.0.1 because the
breaking changes between v10 and v12 do not affect this package.

Closes #13