### PR TITLE
Support invalid arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nyc_output/
 coverage/
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var fs = require('fs')
 var core
 if (process.platform === 'win32' || global.TESTING_WINDOWS) {
   core = require('./windows.js')

--- a/mode.js
+++ b/mode.js
@@ -4,9 +4,13 @@ isexe.sync = sync
 var fs = require('fs')
 
 function isexe (path, options, cb) {
-  fs.stat(path, function (er, stat) {
-    cb(er, er ? false : checkStat(stat, options))
-  })
+  try {
+    fs.stat(path, function (er, stat) {
+      cb(er, er ? false : checkStat(stat, options))
+    })
+  } catch (er) {
+    cb(er, false);
+  }
 }
 
 function sync (path, options) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -7,6 +7,7 @@ var mine = fixture + '/mine.cat'
 var ours = fixture + '/ours.cat'
 var fail = fixture + '/fail.false'
 var noent = fixture + '/enoent.exe'
+var invalid = 5;
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 
@@ -58,6 +59,18 @@ t.test('promise', { skip: promiseSkip }, function (t) {
   })
   t.test('noent ignore async', function (t) {
     isexe(noent, { ignoreErrors: true }).then(function (is) {
+      t.notOk(is)
+      t.end()
+    })
+  })
+  t.test('invalid async', function (t) {
+    isexe(invalid).catch(function (er) {
+      t.ok(er)
+      t.end()
+    })
+  })
+  t.test('invalid ignore async', function (t) {
+    isexe(invalid, { ignoreErrors: true }).then(function (is) {
       t.notOk(is)
       t.end()
     })
@@ -125,6 +138,7 @@ function runTest (t, options) {
     t.notOk(isexe.sync(fail, options))
   }
   t.notOk(isexe.sync(noent, optionsIgnore))
+  t.notOk(isexe.sync(invalid, optionsIgnore))
   if (!options) {
     t.ok(isexe.sync(meow))
   } else {
@@ -135,6 +149,9 @@ function runTest (t, options) {
   t.ok(isexe.sync(ours, options))
   t.throws(function () {
     isexe.sync(noent, options)
+  })
+  t.throws(function () {
+    isexe.sync(invalid, options)
   })
 
   t.test('meow async', function (t) {
@@ -199,6 +216,24 @@ function runTest (t, options) {
 
   t.test('noent ignore async', function (t) {
     isexe(noent, optionsIgnore, function (er, is) {
+      if (er) {
+        throw er
+      }
+      t.notOk(is)
+      t.end()
+    })
+  })
+
+  t.test('invalid async', function (t) {
+    isexe(invalid, options, function (er, is) {
+      t.ok(er)
+      t.notOk(is)
+      t.end()
+    })
+  })
+
+  t.test('invalid ignore async', function (t) {
+    isexe(invalid, optionsIgnore, function (er, is) {
       if (er) {
         throw er
       }

--- a/windows.js
+++ b/windows.js
@@ -32,9 +32,13 @@ function checkStat (stat, path, options) {
 }
 
 function isexe (path, options, cb) {
-  fs.stat(path, function (er, stat) {
-    cb(er, er ? false : checkStat(stat, path, options))
-  })
+  try {
+    fs.stat(path, function (er, stat) {
+      cb(er, er ? false : checkStat(stat, path, options))
+    })
+  } catch (er) {
+    cb(er, false);
+  }
 }
 
 function sync (path, options) {


### PR DESCRIPTION
Makes the library more robust when invalid arguments are passed in. Even with the callback based variants of `fs.stat`, an error will be thrown in that case directly from the method that does not go into the `callback`.