### PR TITLE
fix: include src in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "./dist/mjs/index.js",
   "types": "./dist/cjs/index.js",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "exports": {
     ".": {


### PR DESCRIPTION
Some build systems like Parcel use the src files to build the dependencies on the fly. 

I also noticed that the missing src files cause build issues. Apparently, some other package is importing them while they are not in the package.