### PR TITLE
Remove unused dependency mkdirp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@types/node": "^20.4.5",
         "@types/tap": "^15.0.8",
         "c8": "^8.0.1",
-        "mkdirp": "^0.5.1",
         "prettier": "^2.8.8",
         "rimraf": "^2.5.0",
         "sync-content": "^1.0.2",
@@ -1900,15 +1899,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.2.tgz",
@@ -1916,18 +1906,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/node": "^20.4.5",
     "@types/tap": "^15.0.8",
     "c8": "^8.0.1",
-    "mkdirp": "^0.5.1",
     "prettier": "^2.8.8",
     "rimraf": "^2.5.0",
     "sync-content": "^1.0.2",


### PR DESCRIPTION
The devDependency was added in v1.0.0 https://github.com/isaacs/isexe/blob/d1c8749b748c5ed8bbd16cccd2ef19236b9e673b/test/basic.js#L8, but it's no longer used.